### PR TITLE
Fix GoReleaser Homebrew tap publishing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,7 +35,7 @@ release:
     name: fuzzyrepo
 
 brews:
-  - name: yourtool
+  - name: fuzzyrepo
     homepage: "https://github.com/wealthystudent/fuzzyrepo"
     description: "TUI tool for searching remote and local repositories"
     license: "MIT"
@@ -43,6 +43,7 @@ brews:
       owner: wealthystudent
       name: homebrew-tap
       branch: main
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     directory: Formula
     install: |
       bin.install "fuzzyrepo"


### PR DESCRIPTION
## Problem
GoReleaser release runs were failing when trying to push the Homebrew formula to `wealthystudent/homebrew-tap` with:

- `403 Resource not accessible by integration`

This happens because the default `GITHUB_TOKEN` can’t write to a different repository.

## Fix
- Configure the Homebrew tap integration to use the dedicated PAT provided via `TAP_GITHUB_TOKEN`.
- Rename the brew formula from the placeholder `yourtool` to `fuzzyrepo`.

## Notes
- Workflow already exports `TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}`.
- The PAT should have `Contents: Read and write` on the `homebrew-tap` repo.